### PR TITLE
Add CompanyType

### DIFF
--- a/src/Tmdb.js
+++ b/src/Tmdb.js
@@ -23,6 +23,7 @@ import type {
   MovieType,
   MovieVideoType,
   PersonType,
+  CompanyType,
 } from './types';
 
 type QueryType = {
@@ -156,6 +157,14 @@ class Tmdb {
     });
 
     return person;
+  }
+
+  async getCompany (companyId: number): Promise<CompanyType> {
+    const company = await this.get('company/' + companyId, {
+      language: this.language,
+    })
+
+    return company;
   }
 
   async findId (resourceType: 'movie' | 'person', externalSource: 'imdb', externalId: string): Promise<number> {

--- a/src/Tmdb.js
+++ b/src/Tmdb.js
@@ -162,7 +162,7 @@ class Tmdb {
   async getCompany (companyId: number): Promise<CompanyType> {
     const company = await this.get('company/' + companyId, {
       language: this.language,
-    })
+    });
 
     return company;
   }

--- a/src/bin/generate-types.js
+++ b/src/bin/generate-types.js
@@ -34,6 +34,9 @@ const typeMap = {
   PersonType: (data) => {
     return data.paths['/person/{person_id}'].get.responses['200'].schema.properties;
   },
+  CompanyType: (data) => {
+    return data.paths['/company/{company_id}'].get.responses['200'].schema.properties;
+  },
 };
 
 const definitionMap = {

--- a/src/bin/generate-types.js
+++ b/src/bin/generate-types.js
@@ -121,9 +121,7 @@ const getPropertyFlowType = (property: Object) => {
 };
 
 const run = async () => {
-  const oas = await got('https://api.stoplight.io/v1/versions/9WaNJfGpnnQ76opqe/export/oas.json', {
-    json: true,
-  });
+  const oas = await got('https://api.stoplight.io/v1/versions/9WaNJfGpnnQ76opqe/export/oas.json').json();
 
   for (const typeName of typeNames) {
     const resourceResolver = typeMap[typeName];
@@ -132,7 +130,7 @@ const run = async () => {
       throw new Error('Unexpected state.');
     }
 
-    const typeDefinition = resourceResolver(oas.body);
+    const typeDefinition = resourceResolver(oas);
 
     if (!typeDefinition) {
       throw new Error('Unexpected state.');

--- a/src/bin/generate-types.js
+++ b/src/bin/generate-types.js
@@ -10,6 +10,9 @@ import {
 } from 'lodash';
 
 const typeMap = {
+  CompanyType: (data) => {
+    return data.paths['/company/{company_id}'].get.responses['200'].schema.properties;
+  },
   ImagePathType: (data) => {
     return data.definitions['image-path'].type;
   },
@@ -33,9 +36,6 @@ const typeMap = {
   },
   PersonType: (data) => {
     return data.paths['/person/{person_id}'].get.responses['200'].schema.properties;
-  },
-  CompanyType: (data) => {
-    return data.paths['/company/{company_id}'].get.responses['200'].schema.properties;
   },
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -125,5 +125,5 @@ export type CompanyType = {|
   +logoPath: string,
   +name: string,
   +originCountry: string,
-  +parentCompany: null | CompanyType
+  +parentCompany: null | CompanyType,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -116,3 +116,14 @@ export type PersonType = {|
   +popularity: number,
   +profilePath: ImagePathType,
 |};
+
+export type CompanyType = {|
+  +description: string,
+  +headquarters: string,
+  +homepage: string,
+  +id: number,
+  +logoPath: string,
+  +name: string,
+  +originCountry: string,
+  +parentCompany: null | CompanyType
+|};


### PR DESCRIPTION
Pretty straight-forward except for the issue with the generate-types script. Running on node version v14.6.0 I would get this error:

```
(node:11527) UnhandledPromiseRejectionWarning: TypeError: The `GET` method cannot be used with a body
    at Object.exports.normalizeRequestArguments (/home/marc/code/tmdb/node_modules/got/dist/source/normalize-arguments.js:326:19)
    at get (/home/marc/code/tmdb/node_modules/got/dist/source/request-as-event-emitter.js:45:55)
    at /home/marc/code/tmdb/node_modules/got/dist/source/request-as-event-emitter.js:264:19
(Use `node --trace-warnings ...` to show where the warning was created)
(node:11527) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:11527) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```